### PR TITLE
Fix auth after upgrade admin lte

### DIFF
--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -51,7 +51,7 @@ function check_cors() {
     # Allow user set CORS
     $cors_hosts = getenv('CORS_HOSTS');
     if (! empty($cors_hosts))
-        array_push($AUTHORIZED_HOSTNAMES, ...explode(",", $cors_hosts));
+        array_push($AUTHORIZED_HOSTNAMES, explode(",", $cors_hosts));
 
     // Since the Host header is easily manipulated, we can only check if it's wrong and can't use it
     // to validate that the client is authorized, only unauthorized.


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [ X ] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ X ] I have made only one major change in my proposed changes.
- [ X ] I have commented my proposed changes within the code.
- [ X ] I have tested my proposed changes.
- [ X ] I am willing to help maintain this change if there are issues with it later.
- [ X ] I give this submission freely and claim no ownership.
- [ X ] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ X ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [ X ] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

`After upgrading pi-hole, the initial CORS implementation (created ~ 4 months ago) provides with a blank page when accessing the Web GUI of Pi-Hole.`

**How does this PR accomplish the above?:**

`Fixing explode() function within the array_push to remove the obsolete '...'`

**What documentation changes (if any) are needed to support this PR?:**

`None`